### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Set the base image to micromamba
+FROM mambaorg/micromamba:latest
+
+# File Author / Maintainer
+LABEL org.opencontainers.image.authors="ManuelTgn"
+
+# Set the variables for version control during installation
+ARG crisprhawk_version=0.2.2
+ARG crispritz_version=2.6.6
+
+# set the shell to bash
+ENV SHELL bash
+# set user as root
+USER root
+
+# update packages of the docker image
+RUN apt-get update && \
+    apt-get install -y \
+        gsl-bin \
+        libgsl0-dev \
+        libgomp1 && \
+    apt-get clean
+
+# -----------------------------------------------------------------------------
+# install CRISPR-HAWK in base environment
+# -----------------------------------------------------------------------------
+RUN micromamba install -y -n base \
+    -c conda-forge \
+    -c bioconda \
+    python=3.8 \
+    crisprhawk=${crisprhawk_version} && \
+    micromamba clean --all --yes
+
+# -----------------------------------------------------------------------------
+# create dedicated CRISPRitz environment
+# -----------------------------------------------------------------------------
+RUN micromamba create -y -n crisprhawk-crispritz \
+    -c conda-forge \
+    -c bioconda \
+    python=3.8 \
+    crispritz=${crispritz_version} && \
+    micromamba clean --all --yes
+
+# Needed for micromamba activation
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+# Default command
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -176,7 +176,26 @@ mamba update crisprhawk
 
 ### 1.2 Install CRISPR-HAWK from Docker
 
-TBA
+CRISPR-HAWK is also available through Docker, providing an isolated environment with all required dependencies pre-installed, including a dedicated environment for CRISPRitz.
+
+You can build the Docker image directly from the provided `Dockerfile`:
+
+```bash
+docker build -t crisprhawk .
+```
+
+Once the built, the CRISPR-HAWK Docker image will be ready for use. To confirm the image is successfully installed, you can list all available Docker images by typing:
+```bash
+docker images
+```
+
+Look for an entry similar to the following:
+```text
+REPOSITORY          TAG       IMAGE ID       CREATED        SIZE
+pinellolab/crisprhawk latest    <image_id>     <timestamp>    <size>
+```
+
+You are now ready to run CRISPR-HAWK using Docker.
 
 ### 1.3 Install CRISPR-HAWK from PyPI
 

--- a/src/crisprhawk/config_utils.py
+++ b/src/crisprhawk/config_utils.py
@@ -28,6 +28,7 @@ CONFIG = os.path.abspath(os.path.join(os.path.dirname(__file__), "config/config.
 
 # mamba/conda commands
 MAMBA = "mamba"
+MICROMAMBA = "micromamba"
 CONDA = "conda"
 
 # define crispr-hawk scoring models catalogue
@@ -110,6 +111,8 @@ def set_command() -> str:
     """
     if command_exists(MAMBA):
         return MAMBA
+    if command_exists(MICROMAMBA):
+        return MICROMAMBA
     return CONDA if command_exists(CONDA) else ""
 
 


### PR DESCRIPTION
Add Dockerfile for building/pulling CRISPR-HAWK Docker image.

Update README.md with instructions to build CRISPR-HAWK's Docker image and to test it.

Add micromamba among the command insternally supported to handle external tools requiring dedicated environements.